### PR TITLE
Removed username requirement for authentication

### DIFF
--- a/adapter/server/handler.go
+++ b/adapter/server/handler.go
@@ -78,9 +78,9 @@ func getSwapsHandler(server *server) http.HandlerFunc {
 // information and starts the Atomic Swap.
 func postSwapsHandler(server *server) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		username, password, ok := r.BasicAuth()
-		if !ok || !server.authenticator.VerifyUsernameAndPassword(username, password) {
-			writeError(w, http.StatusUnauthorized, "invalid username or password")
+		_, password, ok := r.BasicAuth()
+		if !ok || !server.authenticator.VerifyPassword(password) {
+			writeError(w, http.StatusUnauthorized, "invalid password")
 			return
 		}
 
@@ -107,9 +107,9 @@ func postSwapsHandler(server *server) http.HandlerFunc {
 // postWithdrawHandler handles the post withdrawal request.
 func postWithdrawHandler(server *server) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		username, password, ok := r.BasicAuth()
-		if !ok || !server.authenticator.VerifyUsernameAndPassword(username, password) {
-			writeError(w, http.StatusUnauthorized, "invalid username or password")
+		_, password, ok := r.BasicAuth()
+		if !ok || !server.authenticator.VerifyPassword(password) {
+			writeError(w, http.StatusUnauthorized, "invalid password")
 			return
 		}
 

--- a/core/auth/auth.go
+++ b/core/auth/auth.go
@@ -7,21 +7,19 @@ import (
 )
 
 type Authenticator interface {
-	VerifyUsernameAndPassword(username, password string) bool
+	VerifyPassword(password string) bool
 }
 
 type authenticator struct {
-	username     string
 	passwordHash [32]byte
 }
 
-func NewAuthenticator(username string, passwordHash [32]byte) Authenticator {
-	return &authenticator{username, passwordHash}
+func NewAuthenticator(passwordHash [32]byte) Authenticator {
+	return &authenticator{passwordHash}
 }
 
-func (authenticator *authenticator) VerifyUsernameAndPassword(username string, password string) bool {
+func (authenticator *authenticator) VerifyPassword(password string) bool {
 	passwordHash := sha3.Sum256([]byte(password))
-	usernameOk := subtle.ConstantTimeCompare([]byte(username), []byte(authenticator.username)) == 1
 	passwordOk := subtle.ConstantTimeCompare(passwordHash[:], authenticator.passwordHash[:]) == 1
-	return usernameOk && passwordOk
+	return passwordOk
 }

--- a/driver/keystore/keystore.go
+++ b/driver/keystore/keystore.go
@@ -83,7 +83,7 @@ func LoadAuthenticator(network string) (auth.Authenticator, error) {
 		return nil, err
 	}
 	passwordHash, err := toBytes32(keystore.PasswordHash)
-	return auth.NewAuthenticator(keystore.Username, passwordHash), nil
+	return auth.NewAuthenticator(passwordHash), err
 }
 
 func Generate(network, username, password string) (string, error) {


### PR DESCRIPTION
**Description**

Removing the username from the authentication process.

**Motivation**

- It is more user-friendly to expect users to only enter password when they are doing authentication.

**Design**

- updated auth service to only verify password
- updated keystore driver to load authenticator using a password hash
- updated server handler to only look for the password in the request