### PR TITLE
Allow delay swapper service to update receipts.

### DIFF
--- a/adapter/db/db.go
+++ b/adapter/db/db.go
@@ -31,7 +31,7 @@ type Storage interface {
 
 	PendingSwap(swapID swap.SwapID) (swap.SwapBlob, error)
 	PutReceipt(receipt swap.SwapReceipt) error
-	UpdateReceipt(swapID swap.SwapID, update func(receipt *swap.SwapReceipt)) error
+	UpdateReceipt(receiptUpdate swap.ReceiptUpdate) error
 	Receipts() ([]swap.SwapReceipt, error)
 	Receipt(swapID swap.SwapID) (swap.SwapReceipt, error)
 	LoadCosts(swapID swap.SwapID) (blockchain.Cost, blockchain.Cost)

--- a/adapter/db/swapper.go
+++ b/adapter/db/swapper.go
@@ -21,8 +21,8 @@ func (db *dbStorage) PutReceipt(receipt swap.SwapReceipt) error {
 	return db.db.Put(append(TableSwapReceipts[:], id...), receiptData, nil)
 }
 
-func (db *dbStorage) UpdateReceipt(swapID swap.SwapID, update func(receipt *swap.SwapReceipt)) error {
-	id, err := base64.StdEncoding.DecodeString(string(swapID))
+func (db *dbStorage) UpdateReceipt(receiptUpdate swap.ReceiptUpdate) error {
+	id, err := base64.StdEncoding.DecodeString(string(receiptUpdate.ID))
 	if err != nil {
 		return err
 	}
@@ -34,7 +34,7 @@ func (db *dbStorage) UpdateReceipt(swapID swap.SwapID, update func(receipt *swap
 	if err := json.Unmarshal(receiptBytes, &receipt); err != nil {
 		return err
 	}
-	update(&receipt)
+	receiptUpdate.Update(&receipt)
 	updatedReceiptBytes, err := json.Marshal(receipt)
 	if err != nil {
 		return err

--- a/core/status/status.go
+++ b/core/status/status.go
@@ -17,7 +17,7 @@ type ReceiptQuery struct {
 type Storage interface {
 	Receipts() ([]swap.SwapReceipt, error)
 	PutReceipt(receipt swap.SwapReceipt) error
-	UpdateReceipt(id swap.SwapID, update func(receipt *swap.SwapReceipt)) error
+	UpdateReceipt(receiptUpdate swap.ReceiptUpdate) error
 }
 type Statuses interface {
 	Run(done <-chan struct{}, swaps <-chan swap.SwapReceipt, updates <-chan swap.ReceiptUpdate, queries <-chan ReceiptQuery)
@@ -64,7 +64,7 @@ func (statuses *statuses) Run(done <-chan struct{}, receipts <-chan swap.SwapRec
 			}
 			statuses.update(update)
 			go func() {
-				if err := statuses.storage.UpdateReceipt(update.ID, update.Update); err != nil {
+				if err := statuses.storage.UpdateReceipt(update); err != nil {
 					statuses.logger.Error(err)
 				}
 			}()

--- a/driver/composer/composer.go
+++ b/driver/composer/composer.go
@@ -67,7 +67,7 @@ func (composer *composer) Run(done <-chan struct{}) {
 		},
 		func() {
 			delayedCallback := delayed.New(callback.New(), storage, logger)
-			delayedCallback.Run(done, delayedSwaps, swaps)
+			delayedCallback.Run(done, delayedSwaps, swaps, receiptUpdates)
 		},
 		func() {
 			swapper := swapper.New(binder.NewBuilder(wallet, logger), storage, logger)


### PR DESCRIPTION
**Description**
The delay swapper fills the unknown details of a swap blob and passes it over to the swapper for execution. Add receipt update ability to it, so that it can make changes to the swap receipts.

**Motivation**
Currently, the delay swapper does not update the swap receipt, so the user still sees the amounts that he set as the maximum limits instead of the values actually being settled on. 

**Design**

- pass receipt updates write channel in the run function of delayed swapper service
- update the UpdateReceipt() interface